### PR TITLE
Update menu items

### DIFF
--- a/src/pages/about/index.mdx
+++ b/src/pages/about/index.mdx
@@ -5,7 +5,7 @@ import Button from "../../components/Button/Button";
 [comment]: # "Page title = h1 in banner"
 
 export const meta = {
-	pageTitle: "About PDCM Finder",
+	pageTitle: "About",
 };
 
 [comment]: # "Page content below"
@@ -40,7 +40,16 @@ Some data for this paper were retrieved from the CancerModels.Org platform, www.
 ## Our data providers
 
 [comment]: # "Do not format this component into multiple lines"
-<Button color="dark" priority="primary" htmlTag="a" href="/about/providers" className="mt-0">View all our data providers</Button>
+
+<Button
+	color="dark"
+	priority="primary"
+	htmlTag="a"
+	href="/about/providers"
+	className="mt-0"
+>
+	View all our data providers
+</Button>
 
 [comment]: # "End page content - do not edit below this line"
 

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -10,16 +10,16 @@ export const routes = [
 		children: [
 			{
 				path: "/about",
-				name: "About PDCM Finder",
+				name: "PDCM Finder",
 			},
-			{
-				path: "/about/metadata-dictionary",
-				name: "Metadata Dictionary",
-			},
-			{
-				path: "/about/faq",
-				name: "FAQ",
-			},
+			// {
+			// 	path: "/about/metadata-dictionary",
+			// 	name: "Metadata Dictionary",
+			// },
+			// {
+			// 	path: "/about/faq",
+			// 	name: "FAQ",
+			// },
 			{
 				path: "/contact",
 				name: "Contact",

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -10,7 +10,7 @@ export const routes = [
 		children: [
 			{
 				path: "/about",
-				name: "PDCM Finder",
+				name: "CancerModels.Org",
 			},
 			// {
 			// 	path: "/about/metadata-dictionary",


### PR DESCRIPTION
## Issue
Fixes #79 

## Description
Update menu items; 
About PDCM Finder > PDCM Finder
Hide Metadata Dictionary and FAQ

## Testing instructions
`localhost:3000` see menu
`http://localhost:3000/about`  we're keeping page title and url as About

