### PR TITLE
Disable clicking on same nav item that user is currently in

### DIFF
--- a/src/components/Navbar/Navbar-desktop/Navbar-desktop.module.scss
+++ b/src/components/Navbar/Navbar-desktop/Navbar-desktop.module.scss
@@ -22,6 +22,7 @@
 		&_link {
 			&-active {
 				text-decoration: underline;
+				pointer-events: none;
 			}
 		}
 		&-firstSecondary {


### PR DESCRIPTION
## Issue
Fixes #92 

## Description

## Testing instructions
Go to search page, apply a filter, try clicking on nav item "search"; page wont refresh nor change url state

## Screenshots (optional)
