### PR TITLE
Publications fetch from client

### DIFF
--- a/src/utils/getModelDetails.ts
+++ b/src/utils/getModelDetails.ts
@@ -24,18 +24,6 @@ const getModelDetails = async (modelId: string, providerId: string) => {
 	const drugDosing = await getModelDrugDosing(pdcmModelId, modelType);
 	const patientTreatment = await getPatientTreatment(pdcmModelId);
 	const qualityData = await getModelQualityData(pdcmModelId);
-	let hasPubmedIds = false;
-	let publications = [];
-	const pubmedIds = await getModelPubmedIds(pdcmModelId);
-	pubmedIds.forEach((id: string) => {
-		if (id) hasPubmedIds = true;
-	});
-	if (hasPubmedIds) {
-		publications = await Promise.all(
-			pubmedIds.map(async (p: string) => await getPublicationData(p))
-		);
-		publications = publications.filter((p) => p.title);
-	}
 
 	return {
 		// deconstruct metadata object so we dont pass more props than we need/should
@@ -55,6 +43,7 @@ const getModelDetails = async (modelId: string, providerId: string) => {
 			licenseName: metadata.licenseName ?? "",
 			licenseUrl: metadata.licenseUrl ?? "",
 			score: metadata.score ?? 0,
+			pdcmModelId,
 			modelId,
 			providerId,
 		},
@@ -65,7 +54,6 @@ const getModelDetails = async (modelId: string, providerId: string) => {
 		drugDosing,
 		patientTreatment,
 		qualityData,
-		publications,
 	};
 };
 


### PR DESCRIPTION
## Issue
Fixes #101 

## Description
Fetch publications on client side so build doesn't make thousands of requests and error out

## Testing instructions
`yarn dev`, visit `http://localhost:3000/data/models/PMLB/PHLC422` and open query dev tools, see publication calls

## Screenshots (optional)
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/25350391/227938112-18aa441d-e533-4810-9f1c-42b155523f34.png">


