### PR TITLE
fix z-index on sidebar and cookie consent

### DIFF
--- a/src/components/CookieConsent/CookieConsent.module.scss
+++ b/src/components/CookieConsent/CookieConsent.module.scss
@@ -1,6 +1,6 @@
 @import "../../styles/vars";
 
 .CookieConsent {
-	z-index: 999;
+	z-index: 9998;
 	border-top: 1px solid $color-primary-primary;
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -361,7 +361,7 @@ hr {
 }
 .sticky {
 	position: sticky;
-	z-index: 9999999;
+	z-index: 9997;
 }
 .top-0 {
 	top: 0 !important;


### PR DESCRIPTION

## Description
fix layering in model id sidebar and cookie consent

## Testing instructions
Visit `http://localhost:3000/data/models/PMLB/PHLC422` in desktop, sidebar "menu" should be under cookie consent

## Screenshots (optional)
<img width="407" alt="image" src="https://user-images.githubusercontent.com/25350391/227949087-e4ac9191-9495-4397-8a12-2265a7cfdce2.png">

