### PR TITLE
Don't scroll to top after filter is selected

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -226,9 +226,13 @@ const Search: NextPage = () => {
 		}
 		if (filterValues.length) {
 			setHasSelection(true);
-			router.replace({
-				query: { ...router.query, filters: filterValues.join(" AND ") },
-			});
+			router.replace(
+				{
+					query: { ...router.query, filters: filterValues.join(" AND ") },
+				},
+				undefined,
+				{ scroll: false }
+			);
 		} else {
 			setHasSelection(false);
 			router.replace("/search", undefined, { shallow: true });


### PR DESCRIPTION
## Issue
Fixes #104 

## Description
After updating a filter, user would be scrolled all the way to the top, causing an annoyance. Removed this scroll to top from this action

## Testing instructions
`yarn dev` > `localhost:3000/search` > select a filter a notice you stay in same scroll position

