### PR TITLE
Score sort options

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -37,6 +37,8 @@ const sortByOptions = [
 		},
 		{ value: "external_model_id.asc", text: "Model Id: A to Z" },
 		{ value: "external_model_id.desc", text: "Model Id: Z to A" },
+		{ value: "score.asc", text: "Metadata: Ascending" },
+		{ value: "score.desc", text: "Metadata: Descending" },
 	],
 	resultsPerPage = 10;
 


### PR DESCRIPTION
## Issue
Fixes #106 

## Description
Enable the user to sort by metadata score

## Testing instructions
`localhost:3000/search` > click "sort by:" select, click any Metadata option

## Screenshots (optional)
<img width="355" alt="image" src="https://user-images.githubusercontent.com/25350391/227995733-c7017106-8220-4bf9-8043-aa36f06a48cf.png">

