### PR TITLE
Fix all models by provider broken link

### DIFF
--- a/src/pages/about/providers/index.tsx
+++ b/src/pages/about/providers/index.tsx
@@ -77,7 +77,7 @@ const Providers: NextPage<IProvidersProps> = ({
 												<Button
 													color="dark"
 													priority="primary"
-													href={`/search?facets=model.data_source:${provider.abbreviation}`}
+													href={`/search?filters=data_source:${provider.abbreviation}`}
 													htmlTag="a"
 												>
 													<>See all {provider.abbreviation} models</>


### PR DESCRIPTION
## Issue
Fixes #108 

## Description
All models by provider was using old filter url syntax

## Testing instructions
go to `https://dev.cancermodels.org/about/providers`, click any "See All X Models", results should be filtered by selected provider

