### PR TITLE
Hitting backspace on empty typeahead adds a blank character selection

### DIFF
--- a/src/components/SearchFilters/SearchFilterContent.tsx
+++ b/src/components/SearchFilters/SearchFilterContent.tsx
@@ -90,6 +90,8 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 								loadingMessage={() => "Loading data"}
 								noOptionsMessage={() => "Type to search"}
 								onChange={(_, actionMeta) => {
+									if (actionMeta.action === "pop-value") return;
+
 									let option = "",
 										action: onFilterChangeType["type"] = "add";
 


### PR DESCRIPTION
## Issue
Fixes #111 

## Description
"typing" backspace added an empty value, removed "pop-value" action from onChange

## Testing instructions
`http://localhost:3000/search` > click on a typeahead and hit backspace ; nothing should happen

