### PR TITLE
Quality badge tooltip

### DIFF
--- a/src/components/QualityBadge/QualityBadge.tsx
+++ b/src/components/QualityBadge/QualityBadge.tsx
@@ -1,3 +1,4 @@
+import Tooltip from "../Tooltip/Tooltip";
 import styles from "./QualityBadge.module.scss";
 
 interface IQualityBadgeProps {
@@ -7,15 +8,19 @@ interface IQualityBadgeProps {
 
 const QualityBadge = (props: IQualityBadgeProps) => {
 	return (
-		<meter
-			className={props.className}
-			min={0}
-			max={100}
-			value={props.score}
-			high={50}
-			low={20}
-			optimum={60}
-		></meter>
+		<Tooltip
+			content={<p className="text-small mb-0 lh-1">Metadata richness score</p>}
+		>
+			<meter
+				className={props.className}
+				min={0}
+				max={100}
+				value={props.score}
+				high={50}
+				low={20}
+				optimum={60}
+			></meter>
+		</Tooltip>
 	);
 };
 


### PR DESCRIPTION
## Issue
Fixes #145 

## Description
Let the user know what the meter is for

## Testing instructions
`localhost:3000/search` and hover over the quality meter in the results card
`http://localhost:3000/data/models/UOC-BC/AB551M1` and hover over the quality meter in the header

## Screenshots (optional)
<img width="699" alt="Screenshot 2023-04-05 at 10 48 02" src="https://user-images.githubusercontent.com/25350391/230046372-c546bdbc-409e-49b5-97e4-93090ff78e45.png">
<img width="556" alt="Screenshot 2023-04-05 at 10 48 10" src="https://user-images.githubusercontent.com/25350391/230046373-4ec80549-eb8d-40d6-a31b-c9cfc1d74cba.png">

