### PR TITLE
Minor - Adjust layout for available data in search result cards

### DIFF
--- a/src/components/SearchResults/SearchResult/SearchResult.module.scss
+++ b/src/components/SearchResults/SearchResult/SearchResult.module.scss
@@ -35,12 +35,9 @@
 	}
 }
 .dataAvailable_grid {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-template-rows: auto auto auto;
-	gap: 20px 15px;
-	grid-template-areas:
-		". ."
-		". ."
-		". .";
+	row-gap: 15px;
+	@include mediaOver("lg") {
+		row-gap: 0;
+		flex-grow: 1;
+	}
 }

--- a/src/components/SearchResults/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult/SearchResult.tsx
@@ -119,20 +119,23 @@ const SearchResult = (props: ISearchResultProps) => {
 							})}
 						</div>
 					</div>
-					<div className="col-12 col-md-12 col-lg-4 mt-3 mt-lg-0">
+					<div className="col-12 col-md-12 col-lg-4 mt-3 mt-lg-0 d-flex flex-column">
 						<p
 							className={`text-center ${styles.SearchResult_availableData_title}`}
 						>
 							Available data
 						</p>
 						<div className={`row ${styles.dataAvailable_grid}`}>
-							{dataTypes.map((dt) => {
+							{dataTypes.map((dt, idx) => {
 								const hasData = dataAvailable?.includes(dt.key),
 									name = dt.name;
+								const isOdd = idx % 2 !== 0;
 
 								return (
-									<div key={dt.key} className={!hasData ? "text-muted" : ""}>
-										<p className="mb-0">
+									<div key={dt.key} className="col-6 h-fit">
+										<p
+											className={`mb-0 ${!hasData ? "text-muted" : ""}`.trim()}
+										>
 											{hasData ? (
 												<Link
 													href={`${modelLink}#${

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -166,6 +166,9 @@ img {
 	&-auto {
 		height: auto;
 	}
+	&-fit {
+		height: fit-content;
+	}
 	@include mediaOver("lg") {
 		&-lg {
 			&-100 {


### PR DESCRIPTION
## Issue
Fixes 

## Description
Better layout for available data in search result card

## Testing instructions
`localhost:3000/search` see result cards

## Screenshots (optional)
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/25350391/230059825-8887fa2a-ea38-42c8-ad2e-57b027dc4013.png">

