### PR TITLE
Minor - Format total results number

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -352,7 +352,7 @@ const Search = ({ modelCount }: ISearchProps) => {
 												? totalResults
 												: (currentPage - 1) * resultsPerPage + resultsPerPage
 										} 
-										of ${totalResults} results`}
+										of ${totalResults.toLocaleString()} results`}
 									</p>
 								</div>
 								<div className="col-12 col-md-6">


### PR DESCRIPTION

## Description
Format total results number so it appears with a coma when it needs to

## Testing instructions
`localhost:3000/search` > see total results in "Showing ..." text

## Screenshots (optional)
<img width="589" alt="image" src="https://user-images.githubusercontent.com/25350391/230080316-44942c16-1d38-4f55-bf45-4f6a8622b0ff.png">

