### PR TITLE
Hide quality badge if score is 0

### DIFF
--- a/src/components/SearchResults/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult/SearchResult.tsx
@@ -92,11 +92,11 @@ const SearchResult = (props: ISearchResultProps) => {
 							</p>
 						</div>
 						<ShowHide showOver={bpLarge} windowWidth={windowWidth}>
-							<QualityBadge score={score} className="w-50" />
+							{score > 0 && <QualityBadge score={score} className="w-50" />}
 						</ShowHide>
 						<p>{histology}</p>
 						<ShowHide hideOver={bpLarge} windowWidth={windowWidth}>
-							<QualityBadge score={score} className="w-50" />
+							{score > 0 && <QualityBadge score={score} className="w-50" />}
 						</ShowHide>
 					</div>
 					<div className="col-12 col-md-6 col-lg-4 mt-3 mt-md-0">

--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -242,7 +242,9 @@ const ModelDetails = ({
 								{metadata.histology} - {metadata.modelType}
 							</h2>
 							<h1 className="m-0 mb-2">{metadata.modelId}</h1>
-							<QualityBadge score={metadata.score} className="w-50" />
+							{metadata.score > 0 && (
+								<QualityBadge score={metadata.score} className="w-50" />
+							)}
 						</div>
 						<div className="col-12 col-md-10 col-lg-5 col-xxx-3 col-xl-5 offset-lg-1 offset-xl-5 offset-xxx-1 offset-md-1 text-right">
 							<p className="mb-1">Provided by</p>


### PR DESCRIPTION
## Issue
Fixes #153 

## Description
Hide badge if score is 0 so it doesn't look empty

## Testing instructions
`localhost:3000/search` > sort by metadata ascending 

## Screenshots (opti
![image](https://user-images.githubusercontent.com/25350391/232244897-21102c71-c12f-484b-8d30-e6fcf97e3f1e.png)
onal)

