### PR TITLE
Fix Ann & Robert image url

### DIFF
--- a/public/static/providers/luriechildrens.md
+++ b/public/static/providers/luriechildrens.md
@@ -1,7 +1,7 @@
 ---
 name: Ann & Robert H Lurie Children's Hospital of Chicago
 abbreviation: LurieChildrens
-logo: img/providers/luriechildrens.png
+logo: img/providers/LurieChildrens.png
 ---
 
 Dr. Li's laboratory is responsible for PIVOT testing involving childhood cancer brain tumor models (e.g., medulloblastoma, ependymoma, high grade gliomas, etc.). Brain tumors are the leading cause of cancer-related death in children. To effectively prioritize drug candidates and improve chances of clinical success, Dr. Li's laboratory developed a large panel (>70) of patient-derived orthotopic PDX (PDOX, or orthotopic PDX) models of malignant pediatric brain tumors through direct implantation of surgical samples as well as autopsied tumor tissues into the matching locations in the brains of SCID mice. These models replicate the histopathological features, molecular subtypes and major genetic abnormalities of the original patient tumors and represent a broad spectrum of potential driver mutation/alternations in pediatric CNS tumors. Dr. Li's laboratory seeks to utilize this novel panel of PDOX models to examine the therapeutic efficacy of new agents and to understand mechanisms of action in order to establish preclinical rationale for expedited translation into clinical trials. ...[Read more](https://www.luriechildrens.org/)


### PR DESCRIPTION
## Issue
Fixes #158 

## Description
Img url on md wasn't camel case

## Testing instructions
`https://www.cancermodels.org/about/providers` > see Ann & Robert H Lurie Children's Hospital of Chicago section

## Screenshots (optional)
<img width="1368" alt="image" src="https://user-images.githubusercontent.com/25350391/234032964-c53210b6-5777-48fd-99f8-937e84ec71db.png">

