### PR TITLE
Add api documentation to about page

### DIFF
--- a/src/pages/about/index.mdx
+++ b/src/pages/about/index.mdx
@@ -41,6 +41,10 @@ If you use PDX-MI in your work, please cite our publication:
 
 <Button color="dark" priority="primary" htmlTag="a" href="/about/providers" className="mt-0">View all our data providers</Button>
 
+## API Documentation
+
+[Learn how to use our open API](https://documenter.getpostman.com/view/6493399/2s8ZDbX1e7)
+
 [comment]: # "End page content - do not edit below this line"
 
 export default ({ children }) => <MdLayout meta={meta}>{children}</MdLayout>;


### PR DESCRIPTION
## Issue
Fixes #161 

## Description
Add api documentation to about page so users can use it on their projects. 

## Testing instructions
`http://localhost:3000/about` scroll to bottom

## Screenshots (optional)
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/25350391/234050479-55b5590d-1be0-4330-a55d-6a9fb8fdc20b.png">

