### PR TITLE
Search - show page number in url

### DIFF
--- a/src/apis/Search.api.ts
+++ b/src/apis/Search.api.ts
@@ -114,7 +114,10 @@ export async function getSearchResults(
 			: "";
 
 	for (const filterId in searchFilterSelection) {
-		if (searchFilterSelection[filterId].selection?.length) {
+		if (
+			searchFilterSelection[filterId].selection?.length &&
+			filterId !== "page"
+		) {
 			const multiValuedFacets = [
 				"search_terms",
 				"dataset_available",
@@ -151,7 +154,7 @@ export async function getSearchResults(
 
 	let response = await fetch(
 		`${API_URL}/search_index?${query}&limit=${pageSize}&offset=${
-			(page - 1) * pageSize
+			(searchFilterSelection["page"].selection[0] - 1) * pageSize
 		}&select=provider_name,patient_age,patient_sex,external_model_id,model_type,data_source,histology,primary_site,collection_site,tumour_type,dataset_available,score&order=${sortBy}.nullslast`,
 		{ headers: { Prefer: "count=exact" } }
 	);


### PR DESCRIPTION
## Issue
Fixes #163 

## Description
Show page number in url to keep it persistent between page changes, bookmarks, etc

## Testing instructions
`localhost:3000/search` and change page to update it in url
`http://localhost:3000/search?filters=page%3A3` should load on third page

## Screenshots (optional)
<img width="696" alt="image" src="https://user-images.githubusercontent.com/25350391/234401891-6fe57d6d-02da-4b42-ba43-3c070d8509e7.png">

