### PR TITLE
On multiple selections, change "all" and "any" labels

### DIFF
--- a/src/components/SearchFilters/SearchFilterContent.tsx
+++ b/src/components/SearchFilters/SearchFilterContent.tsx
@@ -121,7 +121,7 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 										type="radio"
 										name={`operator-${facet.facetId}`}
 										id={`any-${facet.facetId}`}
-										label="Any"
+										label="Or"
 										value="any"
 										defaultChecked={operator === "ANY"}
 										onChange={() =>
@@ -137,7 +137,7 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 										type="radio"
 										name={`operator-${facet.facetId}`}
 										id={`all-${facet.facetId}`}
-										label="All"
+										label="And"
 										value="all"
 										defaultChecked={operator === "ALL"}
 										onChange={() =>


### PR DESCRIPTION
## Issue
Fixes #168 

## Description
In the FE, change multiple selection labels so the user can distinguish easier what they do

## Testing instructions
Open molecular data accordion

## Screenshots (optional)
<img width="330" alt="Screenshot 2023-05-02 at 15 50 02" src="https://user-images.githubusercontent.com/25350391/235796568-e4a58c56-c5c4-4de0-aeb8-81f66b1e508b.png">
