### PR TITLE
Sort patient age filter options

### DIFF
--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -46,16 +46,26 @@ const SearchFilters = (props: ISearchFilters) => {
 					sortObjArrBy(facets, modelFacetOrder, "facetId");
 				}
 
-				const facetOptionsOrder = ["Not Specified", "Not Collected", "Other"];
+				const facetOptionsOrder = [
+					"not specified",
+					"not provided",
+					"not collected",
+					"other",
+				];
 				facets.forEach((facetsFacet) => {
 					if (facetsFacet.options.length) {
-						sortObjArrBy(
-							facetsFacet.options,
-							facetOptionsOrder,
-							undefined,
-							false,
-							false
-						);
+						const matches: string[] = [];
+						const remaining: string[] = [];
+
+						facetsFacet.options.forEach((option) => {
+							if (facetOptionsOrder.includes(option.toLowerCase())) {
+								matches.push(option);
+							} else {
+								remaining.push(option);
+							}
+						});
+
+						facetsFacet.options = [...remaining, ...matches];
 					}
 				});
 


### PR DESCRIPTION
## Issue
Fixes #172 

## Description
Patient age options had "not provided" as a second to last option, should be sent to the end of the list.

## Testing instructions
`localhost:3000/search` open patient age filter, scroll to look at option order

## Screenshots (optional)
