### PR TITLE
Model details - PDX  model engraftment sidebar link

### DIFF
--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -312,8 +312,7 @@ const ModelDetails = ({
 											</Link>
 										</li>
 										<li className="mb-2">
-											{metadata.modelType === "xenograft" &&
-											engraftments?.length ? (
+											{metadata.modelType === "PDX" && engraftments?.length ? (
 												<Link
 													href="#engraftments"
 													className="text-primary-primary"


### PR DESCRIPTION
## Issue
Fixes #186 

## Description
PDX model engraftment element in sidebar doesn't have link even if there's data/table

## Testing instructions
`http://localhost:3000/data/models/UOC-BC/AB551M1` see sidebar, click "PDX Model Engraftment"

## Screenshots (optional)
<img width="1355" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/c38dd7a6-046a-4d14-8b69-0bc2c0df31f7">

