### PR TITLE
Get publications with modelId and providerId

### DIFF
--- a/src/apis/ModelDetails.api.ts
+++ b/src/apis/ModelDetails.api.ts
@@ -18,12 +18,12 @@ export async function getModelDetailsMetadata(
 	return response.json().then((d) => camelCase(d[0]));
 }
 
-export async function getModelPubmedIds(pdcmModelId: number): Promise<any> {
-	if (pdcmModelId !== 0 && !pdcmModelId) {
-		return [];
-	}
+export async function getModelPubmedIds(
+	modelId: string,
+	providerId: string
+): Promise<any> {
 	let response = await fetch(
-		`${process.env.NEXT_PUBLIC_API_URL}/model_information?id=eq.${pdcmModelId}&select=publication_group(pubmed_ids)`
+		`${process.env.NEXT_PUBLIC_API_URL}/model_information?external_model_id=eq.${modelId}&data_source=eq.${providerId}&select=publication_group(pubmed_ids)`
 	);
 	if (!response.ok) {
 		throw new Error("Network response was not ok");

--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -31,7 +31,6 @@ interface IModelDetailsProps {
 	drugDosing: any[];
 	patientTreatment: PatientTreatment[];
 	qualityData: QualityData[];
-	publications: Publication[];
 	className: string;
 	modelId: string;
 	providerId: string;
@@ -203,9 +202,12 @@ const ModelDetails = ({
 			.catch((error) => {});
 	};
 
-	const pdcmModelId = metadata.pdcmModelId || 0;
-	const pubmedIdsQuery = useQuery(["pubmed-ids-data", { pdcmModelId }], () =>
-		getModelPubmedIds(pdcmModelId)
+	const pubmedIdsQuery = useQuery(
+		[
+			"pubmed-ids-data",
+			{ modelId: metadata.modelId, providerId: metadata.providerId },
+		],
+		() => getModelPubmedIds(metadata.modelId, metadata.providerId)
 	);
 
 	const pubmedIds = pubmedIdsQuery.data || [];


### PR DESCRIPTION
## Issue
Fixes #191 

## Description
Get publications for model with modelId and providerId for consistency even after ETL runs

## Testing instructions
`http://localhost:3000/data/models/JAX/TM00025#publications`

## Screenshots (optional)
<img width="1458" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/9e9a4b12-a720-48c7-98b8-fc643d286a84">

