### PR TITLE
Support filtering options with ";"

### DIFF
--- a/src/apis/Search.api.ts
+++ b/src/apis/Search.api.ts
@@ -145,8 +145,8 @@ export async function getSearchResults(
 
 			let optionsQuery =
 				apiOperator === "in"
-					? `(${options.join(",")})`
-					: `{${options.join(",")}}`;
+					? `(${options.join(",").replace(";", "%3B")})`
+					: `{${options.join(",").replace(";", "%3B")}}`;
 
 			query += `&${filterId}=${apiOperator}.${optionsQuery}`;
 		}


### PR DESCRIPTION
## Issue
Fixes #193 

## Description

## Testing instructions
`localhost:3000/search` > in patient ethnicity filter pick an option that includes ";" > models should be shown in results

## Screenshots (optional)
