### PR TITLE
Multivalue filter - No option is added when hitting backspace

### DIFF
--- a/src/components/SearchFilters/SearchFilterContent.tsx
+++ b/src/components/SearchFilters/SearchFilterContent.tsx
@@ -169,6 +169,8 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 								value={defaultValuesObj}
 								options={optionSelectObj}
 								onChange={(_, actionMeta) => {
+									if (actionMeta.action === "pop-value") return;
+
 									let option = "",
 										action: onFilterChangeType["type"] = "add";
 


### PR DESCRIPTION
## Issue
Fixes #197 

## Description
Do nothing if clicking backspace on a searchable multivalue filter

## Testing instructions
`http://localhost:3000/search` > click on multivalue filter eg.Datasource and hit backspace > nothing happens

