### PR TITLE
Group ethnicity filter categories

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -45,7 +45,7 @@ const BarChart = (props: BarChartProps) => {
 			role="application"
 			ariaLabel={props.chartTitle}
 			onClick={(node: any) => {
-				if (node.data.onClickFilters.length > 0) {
+				if (node.data.onClickFilters?.length > 0) {
 					props.onBarClick(node, props.indexKey, true);
 				} else {
 					props.onBarClick(node, props.indexKey);

--- a/src/components/SearchFilters/SearchFilterContent.tsx
+++ b/src/components/SearchFilters/SearchFilterContent.tsx
@@ -8,6 +8,7 @@ import { ChangeEvent, useEffect, useState } from "react";
 import typeaheadStyles from "../../utils/typeaheadStyles";
 import { onFilterChangeType } from "../../pages/search";
 import Fragment from "../Fragment/Fragment";
+import { ethnicityCategories } from "../../utils/collapseEthnicity";
 
 interface ISearchFilterContentProps {
 	data: IFacetProps[];
@@ -50,6 +51,13 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 		setfacetId(facetId);
 	};
 
+	const optionSelectObj = (options: string[]): SelectOption[] => {
+		return options?.map((value: string) => ({
+			["label"]: value,
+			["value"]: value,
+		}));
+	};
+
 	return (
 		<>
 			{props.data.map((facet: IFacetProps) => {
@@ -62,10 +70,7 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 					selection = selectedFacetObj?.selection,
 					operator = selectedFacetObj?.operator;
 
-				const defaultValuesObj = selection?.map((value) => ({
-					["label"]: value,
-					["value"]: value,
-				}));
+				const defaultValues = optionSelectObj(selection);
 
 				if (facetType === "autocomplete" || facetType === "multivalued") {
 					const placeholder = facet.placeholder
@@ -79,8 +84,8 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 								closeMenuOnSelect
 								blurInputOnSelect
 								isMulti
-								defaultValue={defaultValuesObj}
-								value={defaultValuesObj}
+								defaultValue={defaultValues}
+								value={defaultValues}
 								placeholder={placeholder}
 								options={typeaheadData}
 								onInputChange={(inputValue) =>
@@ -155,43 +160,43 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 					);
 				} else if (facetOptions && facetOptions.length > 10) {
 					// Create select typeahead from options
-					const optionSelectObj = facetOptions.map((value) => ({
-						["label"]: value,
-						["value"]: value,
-					}));
+					// Get grouped ethnicity categories from dictionary
+					const optionsSelectObj =
+						facet.facetId !== "patient_ethnicity"
+							? optionSelectObj(facetOptions)
+							: optionSelectObj(Object.keys(ethnicityCategories));
 
 					facetContent = (
-						<>
-							<Select
-								// closeMenuOnSelect={false}
-								isMulti
-								defaultValue={defaultValuesObj}
-								value={defaultValuesObj}
-								options={optionSelectObj}
-								onChange={(_, actionMeta) => {
-									if (actionMeta.action === "pop-value") return;
+						<Select
+							closeMenuOnSelect
+							blurInputOnSelect
+							isMulti
+							defaultValue={defaultValues}
+							value={defaultValues}
+							options={optionsSelectObj}
+							onChange={(_, actionMeta) => {
+								if (actionMeta.action === "pop-value") return;
 
-									let option = "",
-										action: onFilterChangeType["type"] = "add";
+								let option = "",
+									action: onFilterChangeType["type"] = "add";
 
-									switch (actionMeta.action) {
-										case "remove-value":
-											option = actionMeta.removedValue.value;
-											action = "remove";
-											break;
-										case "select-option":
-											option = actionMeta.option!.value;
-											break;
-										case "clear":
-											action = "clear";
-											break;
-									}
+								switch (actionMeta.action) {
+									case "remove-value":
+										option = actionMeta.removedValue.value;
+										action = "remove";
+										break;
+									case "select-option":
+										option = actionMeta.option!.value;
+										break;
+									case "clear":
+										action = "clear";
+										break;
+								}
 
-									props.onFilterChange(facet.facetId, option, operator, action);
-								}}
-								styles={typeaheadStyles}
-							/>
-						</>
+								props.onFilterChange(facet.facetId, option, operator, action);
+							}}
+							styles={typeaheadStyles}
+						/>
 					);
 				} else {
 					// Create checkbox per option

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -19,78 +19,7 @@ import {
 } from "../apis/AggregatedData.api";
 import Link from "next/link";
 import { useRouter } from "next/router";
-
-interface IEthnicityCounter {
-	patient_ethnicity: string;
-	count: number;
-}
-
-function collapseEthnicity(ethnicityList: IEthnicityCounter[]) {
-	const ethnicityEntries = Object.entries({
-		African: "Black Or African American",
-		"African American": "Black Or African American",
-		Black: "Black Or African American",
-		"Black Or African American": "Black Or African American",
-		"Black Or African American; Not Hispanic Or Latino":
-			"Black Or African American",
-		Eastasian: "Asian",
-		"East Asian": "Asian",
-		"South Asian": "Asian",
-		Southasianorhispanic: "Asian",
-		"White; Not Hispanic Or Latino": "White",
-		European: "White",
-		Caucasian: "White",
-		Latino: "Hispanic Or Latino",
-		"White; Hispanic Or Latino": "Hispanic Or Latino",
-		"Not Specified": "Not Provided",
-		Unknown: "Not Provided",
-		"Not Provided": "Not Provided",
-		"Not Collected": "Not Provided",
-		Mixed_or_unknown: "Not Provided",
-		"Declined To Answer": "Not Provided",
-		Other: "Other",
-		Arabic: "Other",
-		"Native Hawaiian Or Other Pacific Islander": "Other",
-		"Not hispanic or Latino": "Other",
-		Asian: "Asian",
-		Hispanic: "Hispanic Or Latino",
-		"Hispanic Or Latino": "Hispanic Or Latino",
-		White: "White",
-	});
-
-	const ethnicityDictionary: any = Object.fromEntries(
-		ethnicityEntries.map(([k, v]: string[]) => [k.toLowerCase(), v])
-	);
-
-	const mappedEthnictyCounts: any = {};
-
-	ethnicityList.forEach((ethnicity) => {
-		const mappedEthnicty =
-			ethnicityDictionary[ethnicity.patient_ethnicity.toLowerCase()];
-
-		if (!mappedEthnictyCounts[mappedEthnicty]) {
-			mappedEthnictyCounts[mappedEthnicty] = 0;
-		}
-
-		mappedEthnictyCounts[mappedEthnicty] += ethnicity.count;
-	});
-
-	return Object.keys(mappedEthnictyCounts).map((e) => {
-		const ethnicityDictionaryArr = ethnicityEntries.map(([k, v]: string[]) => [
-			k,
-			v,
-		]);
-		const subcategories = ethnicityDictionaryArr
-			.filter((subcategory) => subcategory[1] === e)
-			.map((categoryPair) => categoryPair[0]);
-
-		return {
-			patient_ethnicity: e,
-			count: mappedEthnictyCounts[e],
-			onClickFilters: subcategories,
-		};
-	});
-}
+import { countEthnicity } from "../utils/collapseEthnicity";
 
 function collapseAgeGroup(
 	ageGroupList: { patient_age: string; count: number }[]
@@ -312,22 +241,23 @@ const Overview: NextPage = () => {
 										chartTitle="Models by top mutated gene"
 										onBarClick={onGraphClick}
 										rotateTicks={true}
-										data={collapseEthnicity(modelsByPatientEthnicity.data)
-											.sort(
+										data={
+											countEthnicity(modelsByPatientEthnicity.data).sort(
 												(
 													a: { patient_ethnicity: string; count: number },
 													b: { patient_ethnicity: string; count: number }
 												) => b.count - a.count
 											)
-											.filter(
-												(ethnicity: {
-													patient_ethnicity: string;
-													count: number;
-												}) =>
-													!notValidCategories.includes(
-														ethnicity.patient_ethnicity.toLowerCase()
-													)
-											)}
+											// .filter(
+											// 	(ethnicity: {
+											// 		patient_ethnicity: string;
+											// 		count: number;
+											// 	}) =>
+											// 		!notValidCategories.includes(
+											// 			ethnicity.patient_ethnicity.toLowerCase()
+											// 		)
+											// )
+										}
 										indexKey="patient_ethnicity"
 									/>
 								</div>

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -207,18 +207,10 @@ const Search = ({ modelCount }: ISearchProps) => {
 				searchValues: [],
 				searchFilterState,
 				resultsPerPage,
-				currentPage,
 				sortBy,
 			},
 		],
-		async () =>
-			getSearchResults(
-				[],
-				searchFilterState,
-				currentPage,
-				resultsPerPage,
-				sortBy
-			)
+		async () => getSearchResults([], searchFilterState, resultsPerPage, sortBy)
 	);
 
 	useEffect(() => {

--- a/src/utils/collapseEthnicity.ts
+++ b/src/utils/collapseEthnicity.ts
@@ -1,0 +1,67 @@
+interface IEthnicityCounter {
+	patient_ethnicity: string;
+	count: number;
+}
+
+interface IEthnicityCategories {
+	[key: string]: string[];
+}
+
+export const ethnicityCategories: IEthnicityCategories = {
+	Asian: [
+		"Eastasian",
+		"East Asian",
+		"South Asian",
+		"Southasianorhispanic",
+		"Asian",
+	],
+	"Black Or African American": [
+		"African",
+		"African American",
+		"Black",
+		"Black Or African American",
+		"Black Or African American; Not Hispanic Or Latino",
+	],
+	White: ["White; Not Hispanic Or Latino", "European", "Caucasian", "White"],
+	"Hispanic Or Latino": [
+		"Latino",
+		"White; Hispanic Or Latino",
+		"Hispanic",
+		"Hispanic Or Latino",
+	],
+	"Not Provided": [
+		"Not Specified",
+		"Unknown",
+		"Not Provided",
+		"Not Collected",
+		"Mixed_or_unknown",
+		"Declined To Answer",
+	],
+	Other: [
+		"Other",
+		"Arabic",
+		"Native Hawaiian Or Other Pacific Islander",
+		"Not Hispanic Or Latino",
+	],
+};
+
+export function countEthnicity(subethnicityCountList: IEthnicityCounter[]) {
+	const ethnictyCounts: { [key: string]: number } = {};
+
+	subethnicityCountList.forEach((subethnicity) => {
+		for (let key in ethnicityCategories) {
+			if (ethnicityCategories[key].includes(subethnicity.patient_ethnicity)) {
+				if (!ethnictyCounts[key]) ethnictyCounts[key] = 0;
+
+				ethnictyCounts[key] += subethnicity.count;
+			}
+		}
+	});
+
+	return Object.keys(ethnictyCounts).map((e) => {
+		return {
+			patient_ethnicity: e,
+			count: ethnictyCounts[e],
+		};
+	});
+}


### PR DESCRIPTION
## Issue
Fixes #179 

## Description
Ethnicity filter and overview chart have same top level categories. When filtering by them, results show subcategories

## Testing instructions
`localhost:3000/search` > open patient ethnicity filter > notice only top level categories > click to see results of subcategories
`localhost:3000/overview` > observe ethnicity count chart > notice only top level categories > click to see results of subcategories
