### PR TITLE
Search page - filter button only clears filters

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -85,8 +85,10 @@ const Search = ({ modelCount }: ISearchProps) => {
 				if (actionInitialState) return actionInitialState;
 
 				for (let key in state) {
-					newState[key].selection = [];
-					newState[key].operator = "ANY";
+					if (key !== "search_terms") {
+						newState[key].selection = [];
+						newState[key].operator = "ANY";
+					}
 				}
 			}
 


### PR DESCRIPTION
## Issue
Fixes #208 

## Description
When clicking on [enabled] filter clear button, cancer diagnosis search terms (top bar) don't clear

## Testing instructions
`http://localhost:3000/search?filters=model_type%3Aorganoid+AND+search_terms%3AEsophageal+Adenocarcinoma` > click filter clear button > see cancer diagnosis term still there