### PR TITLE
Show score on quality badge hover

### DIFF
--- a/src/components/QualityBadge/QualityBadge.tsx
+++ b/src/components/QualityBadge/QualityBadge.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties } from "react";
+import Tooltip from "../Tooltip/Tooltip";
 
 interface IQualityBadgeProps {
 	className?: string;
@@ -10,16 +11,18 @@ interface IQualityBadgeProps {
 const QualityBadge = (props: IQualityBadgeProps) => {
 	return (
 		<div className={props.containerClassName}>
-			<meter
-				className={props.className}
-				min={0}
-				max={100}
-				value={props.score}
-				high={70}
-				low={30}
-				optimum={90}
-				style={props.style}
-			></meter>
+			<Tooltip content={<span className="text-small">{props.score}</span>}>
+				<meter
+					className={props.className}
+					min={0}
+					max={100}
+					value={props.score}
+					high={70}
+					low={30}
+					optimum={90}
+					style={props.style}
+				></meter>
+			</Tooltip>
 			<p className="text-small m-0">Model characterisation</p>
 		</div>
 	);


### PR DESCRIPTION
## Issue
Fixes #219 

## Description
Show a tooltip with the quality badge score when hovering

## Testing instructions
`http://localhost:3000/search` > hover over any quality badge
`http://localhost:3000/data/models/UOM-BC/BB6RC37` > hover over quality badge 

## Screenshots (optional)
<img width="425" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/f91e161b-7dc8-4982-9d0f-69bf80e60ce3">
<img width="699" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/07b32684-a45e-4726-89a1-8790e5a37441">

