### PR TITLE
Quality badge - Include descriptive text

### DIFF
--- a/src/components/QualityBadge/QualityBadge.module.scss
+++ b/src/components/QualityBadge/QualityBadge.module.scss
@@ -1,0 +1,12 @@
+@import "../../styles/mixins";
+
+.QualityBadge {
+	&_toolTip {
+		&_p {
+			text-transform: none;
+			@include mediaOver("sm") {
+				width: 300px;
+			}
+		}
+	}
+}

--- a/src/components/QualityBadge/QualityBadge.tsx
+++ b/src/components/QualityBadge/QualityBadge.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties } from "react";
 import Tooltip from "../Tooltip/Tooltip";
+import styles from "./QualityBadge.module.scss";
 
 interface IQualityBadgeProps {
 	className?: string;
@@ -11,7 +12,19 @@ interface IQualityBadgeProps {
 const QualityBadge = (props: IQualityBadgeProps) => {
 	return (
 		<div className={props.containerClassName}>
-			<Tooltip content={<span className="text-small">{props.score}</span>}>
+			<Tooltip
+				content={
+					<>
+						<span className="text-bold">{props.score}%</span>
+						<p
+							className={`text-small mb-0 mt-1 ${styles.QualityBadge_toolTip_p}`}
+						>
+							Score related to the amount of information available about the
+							model, not the quality of the model.
+						</p>
+					</>
+				}
+			>
 				<meter
 					className={props.className}
 					min={0}


### PR DESCRIPTION
## Issue
Fixes #223 

## Description
Add descriptive text for users to understand what the score/badge means

## Testing instructions
`http://localhost:3000/search` > hover quality badge

## Screenshots (optional)
<img width="846" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/d71f4aed-b2d2-44b6-9fe3-4378a81f4d7b">
