### PR TITLE
Show external resource on raw data column in molecular data table

### DIFF
--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -592,10 +592,18 @@ const ModelDetails = ({
 															const sampleType = data.xenograftSampleId
 																? "Engrafted Tumour"
 																: "Patient Tumour";
-															const rawDataExternalLink =
-																data.externalDbLinks?.find(
-																	(data) => data.column === "raw_data_url"
-																)?.link;
+															const hasExternalDbLinks =
+																data.externalDbLinks?.length > 0;
+															let rawDataExternalLinks: ExternalDbLinks[] = [];
+															if (hasExternalDbLinks) {
+																data.externalDbLinks
+																	?.filter(
+																		(data) => data.column === "raw_data_url"
+																	)
+																	.forEach((obj) =>
+																		rawDataExternalLinks.push(obj)
+																	);
+															}
 
 															return (
 																<tr key={data.id}>
@@ -645,17 +653,22 @@ const ModelDetails = ({
 																	</td>
 																	<td>{data.platformName}</td>
 																	<td>
-																		{data.rawDataUrl ? (
-																			<a
-																				href={rawDataExternalLink}
-																				target="_blank"
-																				rel="noopener noreferrer"
-																			>
-																				{data.rawDataUrl.split(",")[0]}
-																			</a>
-																		) : (
-																			"Not available"
-																		)}
+																		{hasExternalDbLinks
+																			? rawDataExternalLinks?.map(
+																					(externalResource) => (
+																						<>
+																							<Link
+																								href={externalResource.link}
+																								target="_blank"
+																								rel="noopener noreferrer"
+																							>
+																								{externalResource.resource}
+																							</Link>
+																							<br />
+																						</>
+																					)
+																			  )
+																			: "Not available"}
 																	</td>
 																</tr>
 															);


### PR DESCRIPTION
## Issue
Fixes #251 

## Description
Show external resource on raw data column in molecular data table

## Testing instructions
`http://localhost:3000/data/models/IRCC-CRC/CRC0131LM` > Should show resources
`http://localhost:3000/data/models/CRL/CRL-1114` > shouldn't show resources ("Not available")

## Screenshots (optional)
![image](https://github.com/PDCMFinder/cancer-models/assets/25350391/1e60e370-1727-4a4f-b7f1-7da2d31ed4b3)
![image](https://github.com/PDCMFinder/cancer-models/assets/25350391/92a22d7f-44f9-4de5-97a1-0e63bd2e13b5)

