### PR TITLE
Tool tip - z-index, copyable

### DIFF
--- a/src/components/Tooltip/Tooltip.module.scss
+++ b/src/components/Tooltip/Tooltip.module.scss
@@ -2,7 +2,7 @@
 
 .Tooltip {
 	$--content-bgColor: $color-primary-secondary;
-	--content-separation: calc(100% + 10px);
+	--content-separation: 100%;
 	&_content {
 		color: $color-white;
 		position: absolute;
@@ -13,6 +13,7 @@
 		transform: translateY(-50%);
 		background-color: $--content-bgColor;
 		line-height: 1;
+		z-index: 9998;
 	}
 	&_arrow {
 		--arrow-width: 0.7rem;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -15,7 +15,7 @@ const Tooltip = (props: ITooltipProps) => {
 			<div
 				onMouseOver={() => setIsHovering(true)}
 				onMouseLeave={() => setIsHovering(false)}
-				className="d-inline position-relative"
+				className="d-inline position-relative pr-2"
 			>
 				{isHovering && (
 					<>


### PR DESCRIPTION
## Issue
Fixes #253 

## Description
Now able to copy tooltip text; higher than other elements

## Testing instructions
`http://localhost:3000/compare?models=T241+T127+T283+CRL-508`

## Screenshots (optional)
<img width="635" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/71328efe-5de3-4271-bdab-718cf110008e">

