### PR TITLE
Update page names, add pages to submenu

### DIFF
--- a/src/components/ActiveLink/ActiveLink.tsx
+++ b/src/components/ActiveLink/ActiveLink.tsx
@@ -17,6 +17,12 @@ const ActiveLink = ({
 	const [computedClassName, setComputedClassName] =
 		useState<string | undefined>(className);
 	const [isActive, setIsActive] = useState<boolean>(false);
+	const externalLinkProps = props.href.toString().includes("http")
+		? {
+				target: "_blank",
+				rel: "noopener noreferrer",
+		  }
+		: null;
 
 	useEffect(() => {
 		// Check if the router fields are updated client-side
@@ -56,6 +62,7 @@ const ActiveLink = ({
 		<Link
 			className={computedClassName}
 			{...props}
+			{...externalLinkProps}
 			data-test={isActive ? "activeLink-active" : undefined}
 		>
 			{children}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -54,12 +54,12 @@ const Button = (props: IButtonProps) => {
 	};
 
 	if (props.htmlTag === "a" && href) {
-		if (href.includes("https://") || href.includes("http://")) {
-			externalLinkProps = {
-				target: "_blank",
-				rel: "noopener noreferrer",
-			};
-		}
+		const externalLinkProps = href.includes("http")
+			? {
+					target: "_blank",
+					rel: "noopener noreferrer",
+			  }
+			: null;
 
 		return (
 			<Link

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -58,7 +58,7 @@ const Footer = (props: IFooterProps) => {
 									{routes.map((route) => {
 										let children = route.children;
 
-										if (route.name === "About" && children) {
+										if (route.name === "More" && children) {
 											return children.map((child) => (
 												<li key={child.path}>
 													<ActiveLink

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,9 +7,7 @@ import Link from "next/link";
 import { useQuery } from "react-query";
 import { getDataReleaseInformation } from "../../apis/AggregatedData.api";
 import { hj_event } from "../../utils/hotjar";
-interface IFooterProps {
-	cookieConsentHeight: number;
-}
+
 interface IFooterProps {
 	cookieConsentHeight: number;
 }

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -33,9 +33,6 @@ function generateSiteMap(providers: string[], host: string): string {
       <url>
         <loc>${host}/privacy-policy</loc>
       </url>
-      <url>
-        <loc>${host}/about/providers</loc>
-      </url>
       ${providers
 				.map(
 					(provider) =>

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -6,7 +6,7 @@ export const routes = [
 	{ path: "/submit", name: "Submit" },
 	{ path: "/overview", name: "Overview" },
 	{
-		name: "About",
+		name: "More",
 		children: [
 			{
 				path: "/about",

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,10 +1,10 @@
 // children: if it has children, it is parent; children of that item
+// If adding a page that already existed, check sitemaps so it's not duplicated
 export const routes = [
 	{ path: "/", name: "Home" },
 	{ path: "/search", name: "Search" },
-	{ path: "/submit", name: "Submit Data" },
-	{ path: "/overview", name: "Data Overview" },
-	// { path: "/blog", name: "Blog" },
+	{ path: "/submit", name: "Submit" },
+	{ path: "/overview", name: "Overview" },
 	{
 		name: "About",
 		children: [
@@ -12,14 +12,18 @@ export const routes = [
 				path: "/about",
 				name: "CancerModels.Org",
 			},
-			// {
-			// 	path: "/about/metadata-dictionary",
-			// 	name: "Metadata Dictionary",
-			// },
-			// {
-			// 	path: "/about/faq",
-			// 	name: "FAQ",
-			// },
+			{
+				path: "/about/providers",
+				name: "Data Providers",
+			},
+			{
+				path: "https://documenter.getpostman.com/view/6493399/2s8ZDbX1e7",
+				name: "API",
+			},
+			{
+				path: "/training",
+				name: "Training",
+			},
 			{
 				path: "/contact",
 				name: "Contact",


### PR DESCRIPTION
## Issue
Fixes #262 

## Description
Update page names so they're more concise, add some pages that we're in `/about` to the nav submenu

## Testing instructions
`http://localhost:3000` > see nav menu and footer > hover `About` button on nav

## Screenshots (optional)
<img width="828" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/da17a5d3-b9ef-4bf1-b465-aed85f0c1f68">
