### PR TITLE
Remove extra scroll bars in model details page tables

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -85,6 +85,7 @@ const Layout = (props: ILayoutProps) => {
 				<DynamicFooter cookieConsentHeight={cookieConsentHeight} />
 				{!cookies["cm_feedback"] && (
 					<DynamicModal
+						className="overflow-hidden"
 						style={{ maxWidth: "500px" }}
 						modalWidth="100"
 						handleClose={() =>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,6 +5,7 @@ interface IModalProps {
 	children: string | JSX.Element;
 	modalWidth?: "100" | "50" | "auto";
 	verticalAlign?: "center" | "top";
+	className?: string;
 	handleClose: () => void;
 	style?: CSSProperties;
 }
@@ -13,6 +14,7 @@ const Modal = ({
 	children,
 	modalWidth = "auto",
 	verticalAlign = "center",
+	className,
 	handleClose,
 	style,
 }: IModalProps) => {
@@ -42,8 +44,8 @@ const Modal = ({
 				onClick={handleClose}
 			></div>
 			<div
-				className={`${styles.Modal} ${
-					styles[`Modal-${verticalAlign}`]
+				className={`${styles.Modal} ${styles[`Modal-${verticalAlign}`]} ${
+					className ?? ""
 				} position-fixed w-${modalWidth}`}
 				style={style}
 			>

--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -441,7 +441,7 @@ const ModelDetails = ({
 								<div id="engraftments" className="row mb-5 pt-3">
 									<div className="col-12 mb-1">
 										<h2 className="mt-0">PDX model engraftment</h2>
-										<div className="overflow-scroll showScrollbar-vertical">
+										<div className="overflow-auto showScrollbar-vertical">
 											<table>
 												<caption>PDX model engraftment</caption>
 												<thead>
@@ -537,7 +537,7 @@ const ModelDetails = ({
 								<div id="quality-control" className="row mb-5 pt-3">
 									<div className="col-12 mb-1">
 										<h2 className="mt-0">Model quality control</h2>
-										<div className="overflow-scroll showScrollbar-vertical">
+										<div className="overflow-auto showScrollbar-vertical">
 											<table>
 												<caption>Model quality control</caption>
 												<thead>
@@ -575,7 +575,7 @@ const ModelDetails = ({
 								<div id="molecular-data" className="row mb-5 pt-3">
 									<div className="col-12 mb-1">
 										<h2 className="mt-0">Molecular data</h2>
-										<div className="overflow-scroll showScrollbar-vertical">
+										<div className="overflow-auto showScrollbar-vertical">
 											<table>
 												<caption>Molecular data</caption>
 												<thead>
@@ -725,7 +725,7 @@ const ModelDetails = ({
 								<div id="dosing-studies" className="row mb-5 pt-3">
 									<div className="col-12 mb-1">
 										<h2 className="mt-0">Dosing studies</h2>
-										<div className="overflow-scroll showScrollbar-vertical">
+										<div className="overflow-auto showScrollbar-vertical">
 											<table>
 												<caption>Dosing studies</caption>
 												<thead>
@@ -759,7 +759,7 @@ const ModelDetails = ({
 								<div id="patient-treatment" className="row mb-5 pt-3">
 									<div className="col-12 mb-1">
 										<h2 className="mt-0">Patient treatment</h2>
-										<div className="overflow-scroll showScrollbar-vertical">
+										<div className="overflow-auto showScrollbar-vertical">
 											<table>
 												<caption>Patient treatment</caption>
 												<thead>

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -385,6 +385,9 @@ hr {
 	&-visible {
 		overflow: visible !important;
 	}
+	&-auto {
+		overflow: auto !important;
+	}
 }
 .top-0 {
 	top: 0 !important;


### PR DESCRIPTION
## Issue
Fixes #295 

## Description
Remove empty/unused scrollbars from tables and from feedback modal on Windows + Firefox 

## Testing instructions
Windows + firefox > `http://localhost:3000/data/models/NKI/T250`

