### PR TITLE
Add repositories link to about page

### DIFF
--- a/src/pages/about/index.mdx
+++ b/src/pages/about/index.mdx
@@ -39,11 +39,15 @@ If you use PDX-MI in your work, please cite our publication:
 
 [comment]: # "Do not format this component into multiple lines"
 
-<Button color="dark" priority="primary" htmlTag="a" href="/about/providers" className="my-0">View all our data providers</Button>
+[View all our data providers](/about/providers)
+
+## Open source repositories
+
+<a href="https://github.com/PDCMFinder/" target="_blank" rel="noopener noreferrer">Cancer Models organization</a>
 
 ## API Documentation
 
-[Learn how to use our open API](https://documenter.getpostman.com/view/6493399/2s8ZDbX1e7)
+<a href="https://documenter.getpostman.com/view/6493399/2s8ZDbX1e7" target="_blank" rel="noopener noreferrer">Learn how to use our open API</a>
 
 ## CancerModels.Org training materials
 


### PR DESCRIPTION
## Issue
Fixes #299 

## Description
Add organizations link to about page so users can use/edit/view our open source code

## Testing instructions
`http://localhost:3000/about` > scroll and view link

## Screenshots (optional)
<img width="1088" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/4a4aa5fb-0087-48d6-9e0f-2a5ebca512b7">

