### PR TITLE
Add support to immunemarker data

### DIFF
--- a/src/apis/Search.api.ts
+++ b/src/apis/Search.api.ts
@@ -127,6 +127,7 @@ export async function getSearchResults(
 				"markers_with_expression_data",
 				"markers_with_biomarker_data",
 				"custom_treatment_type_list",
+				"immunemarkers_names",
 			];
 			let options: string[] = searchFilterSelection[filterId].selection.map(
 				(d: string) => `"${d}"`


### PR DESCRIPTION
## Issue
Fixes #305 

## Description
Add endpoint to multivalued facet list so it uses `ov.` operator

## Testing instructions
`http://localhost:3000/search?filters=immunemarkers_names%3AHLA-A%2CHLA-B%2CHLA-C` should show results
`http://localhost:3000/search` > use immunemarkers filter
