### PR TITLE
Move pagination position

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -501,17 +501,19 @@ const Search: NextPage = () => {
 							) : (
 								<SearchResultsLoader amount={resultsPerPage} />
 							)}
-						</div>
-						<div className="col-12 col-lg-9 offset-lg-3">
-							<Pagination
-								totalPages={
-									totalResults !== 0
-										? Math.ceil(totalResults / resultsPerPage)
-										: 1
-								}
-								currentPage={currentPage}
-								onPageChange={(page: number) => changePage(page)}
-							/>
+							<div className="row">
+								<div className="col-12">
+									<Pagination
+										totalPages={
+											totalResults !== 0
+												? Math.ceil(totalResults / resultsPerPage)
+												: 1
+										}
+										currentPage={currentPage}
+										onPageChange={(page: number) => changePage(page)}
+									/>
+								</div>
+							</div>
 						</div>
 					</div>
 					{modelsToCompare[0] ? (


### PR DESCRIPTION
## Issue
Fixes #307 

## Description
Move pagination position so it's underneath the search results when filters are open, instead of always at the bottom of the page

## Testing instructions
`http://localhost:3000/search` > open filters > notice pagination is always just under search results

## Screenshots (optional)
<img width="1481" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/52c0b46c-377d-4130-8720-f881efa063de">
