### PR TITLE
Bio markers spelling in search result card

### DIFF
--- a/src/components/SearchResults/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult/SearchResult.tsx
@@ -21,8 +21,8 @@ const dataTypes = [
 		sectionLink: "molecular-data",
 	},
 	{
-		key: "biomarker",
-		name: "Biomarker",
+		key: "bio markers",
+		name: "Bio Markers",
 		sectionLink: "molecular-data",
 	},
 	{
@@ -146,7 +146,7 @@ const SearchResult = (props: ISearchResultProps) => {
 						{dataTypes.map((dt) => {
 							const hasData = dataAvailable?.includes(dt.key),
 								name = dt.name;
-
+							console.log(dataAvailable);
 							return (
 								<div key={dt.key} className="col-6 h-fit">
 									<p className={`mb-0 ${!hasData ? "text-muted" : ""}`.trim()}>

--- a/src/components/SearchResults/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult/SearchResult.tsx
@@ -146,7 +146,7 @@ const SearchResult = (props: ISearchResultProps) => {
 						{dataTypes.map((dt) => {
 							const hasData = dataAvailable?.includes(dt.key),
 								name = dt.name;
-							console.log(dataAvailable);
+
 							return (
 								<div key={dt.key} className="col-6 h-fit">
 									<p className={`mb-0 ${!hasData ? "text-muted" : ""}`.trim()}>


### PR DESCRIPTION
## Issue
Fixes #314 

## Description
Add space to `bio markers` in search result card

## Testing instructions
`http://localhost:3000/search?filters=dataset_available%3Abio+markers`

## Screenshots (optional)
<img width="721" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/3c834223-4270-49be-93af-1c91055dc887">
