### PR TITLE
Add immune marker row to available data in compare page

### DIFF
--- a/src/pages/compare.tsx
+++ b/src/pages/compare.tsx
@@ -565,6 +565,25 @@ const Compare: NextPage = () => {
 								<div className={`row ${styles.Compare_row}`}>
 									<div className="col-3">
 										<p className="text-uppercase">
+											<b>Immune markers</b>
+										</p>
+									</div>
+									{allModelsData.map(({ data }) => (
+										<div
+											className="col"
+											key={data?.metadata.modelId + "immuneMarkers"}
+										>
+											<p>
+												{data?.immuneMarkers && data?.immuneMarkers.length > 0
+													? CHECKMARK_STRING
+													: ""}
+											</p>
+										</div>
+									))}
+								</div>
+								<div className={`row ${styles.Compare_row}`}>
+									<div className="col-3">
+										<p className="text-uppercase">
 											<b>Drug dosing</b>
 										</p>
 									</div>


### PR DESCRIPTION
## Issue
Fixes #324 

## Description
Adds immune marker row to available data in comapre page as a checkmark if any is vavailable, empty column if not

## Testing instructions
`http://localhost:3000/compare?models=T336+T250+CRL-1876+CRL-1584` > see there's checkmarks and empty columns

## Screenshots (optional)
<img width="1468" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/e21563b2-c04c-4cf5-b936-914fc9eb0e57">

