### PR TITLE
Set min height for modal / mobile search filters

### DIFF
--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -3,12 +3,13 @@
 .Modal_backdrop {
 	background-color: rgba(0, 0, 0, 0.75);
 	z-index: 9999999999;
+	left: 0;
 }
 .Modal {
 	z-index: 9999999999;
 	overflow-x: hidden;
 	overflow-y: scroll;
-	min-height: min-content;
+	min-height: initial;
 	height: auto;
 	max-height: 100%;
 	top: $spacing-2;


### PR DESCRIPTION
## Issue
Fixes #350 

## Description
Mobile search filters in modal now have a min-height of "initial", so they can work on Safari

## Testing instructions
`localhost:3000/search` on mobile > open filter modal and scroll down
