### PR TITLE
Add EBI data preservation link

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -186,6 +186,16 @@ const Footer = (props: IFooterProps) => {
 							>
 								EMBL-EBI terms of use.
 							</Link>
+							<br />
+							Our platform also conforms to the EMBL-EBI{" "}
+							<a
+								target="_blank"
+								rel="noreferrer noopener"
+								className="link-text-light"
+								href="https://www.ebi.ac.uk/long-term-data-preservation"
+							>
+								long-term data preservation policies.
+							</a>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
## Issue
Fixes #388 

## Description
Adds EBI data preservation link to the end of the footer

## Testing instructions
Scroll all the way to the bottom of the footer, see new line

## Screenshots (optional)
<img width="1430" alt="image" src="https://github.com/PDCMFinder/cancer-models/assets/25350391/5ca58e64-26a8-4723-84ad-bd897fa2f1e2">

