### PR TITLE
Don't show broken histology images

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
 	"prettier.useTabs": true,
-	"editor.tabSize": 2
+	"editor.tabSize": 2,
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/apis/ModelDetails.api.ts
+++ b/src/apis/ModelDetails.api.ts
@@ -93,7 +93,9 @@ export async function getModelImages(modelId: string): Promise<ModelImage[]> {
 	});
 }
 
-export async function getModelRelationships(modelId: string): Promise<any> {
+export async function getModelRelationships(
+	modelId: string
+): Promise<ModelRelationships> {
 	let response = await fetch(
 		`${process.env.NEXT_PUBLIC_API_URL}/search_index?external_model_id=eq.${modelId}&select=model_relationships`
 	);
@@ -110,7 +112,7 @@ export async function getModelRelationships(modelId: string): Promise<any> {
 export async function getModelPubmedIds(
 	modelId: string = "",
 	providerId: string
-): Promise<any> {
+): Promise<string[]> {
 	let response = await fetch(
 		`${process.env.NEXT_PUBLIC_API_URL}/model_information?external_model_id=eq.${modelId}&data_source=eq.${providerId}&select=publication_group(pubmed_ids)`
 	);

--- a/src/components/ImageChecker/ImageChecker.tsx
+++ b/src/components/ImageChecker/ImageChecker.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+interface ImageCheckerProps {
+	src: string;
+	children: JSX.Element;
+}
+
+const ImageChecker = (props: ImageCheckerProps) => {
+	const [isBroken, setIsBroken] = useState(false);
+
+	useEffect(() => {
+		const img = new Image();
+		img.onerror = () => setIsBroken(true);
+		img.src = props.src;
+	}, [props.src]);
+
+	return !isBroken ? props.children : <></>;
+};
+
+export default ImageChecker;

--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -5,8 +5,9 @@ import JSZip from "jszip";
 import { GetStaticPaths, GetStaticProps } from "next";
 import dynamic from "next/dynamic";
 import Head from "next/head";
+import Image from "next/image";
 import Link from "next/link";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import ReactGA from "react-ga4";
 import { useQueries, useQuery } from "react-query";
 import {
@@ -20,6 +21,7 @@ import Button from "../../../../components/Button/Button";
 import Card from "../../../../components/Card/Card";
 import CloseIcon from "../../../../components/CloseIcon/CloseIcon";
 import FloatingButton from "../../../../components/FloatingWidget/FloatingButton";
+import ImageChecker from "../../../../components/ImageChecker/ImageChecker";
 import InputAndLabel from "../../../../components/Input/InputAndLabel";
 import Loader from "../../../../components/Loader/Loader";
 import MolecularDataTable from "../../../../components/MolecularDataTable/MolecularDataTable";
@@ -30,6 +32,7 @@ import useWindowDimensions from "../../../../hooks/useWindowDimensions";
 import {
 	AllModelData,
 	ExternalDbLink,
+	ModelImage,
 	MolecularData,
 	Publication
 } from "../../../../types/ModelData.model";
@@ -38,6 +41,7 @@ import {
 	constructCleanMolecularDataFilename,
 	constructMolecularDataFilename
 } from "../../../../utils/constructMolecularDataFilename";
+import imageIsBrokenChecker from "../../../../utils/imageIsBrokenChecker";
 import { modelTourSteps } from "../../../../utils/tourSteps";
 import styles from "./Model.module.scss";
 
@@ -115,6 +119,18 @@ const ModelDetails = ({
 		{ label: "Primary Site", value: metadata.primarySite },
 		{ label: "Collection Site", value: metadata.collectionSite }
 	];
+
+	const [validHistologyImages, setValidHistologyImages] = useState<
+		ModelImage[]
+	>([]);
+	const checkImages = async (modelImages: ModelImage[]) => {
+		const checkedImages = await imageIsBrokenChecker(modelImages);
+		setValidHistologyImages(checkedImages);
+	};
+	useEffect(() => {
+		checkImages(modelImages);
+	}, []);
+
 	const driverObj = driver({
 		showProgress: true,
 		prevBtnText: "← Prev",
@@ -716,7 +732,7 @@ const ModelDetails = ({
 											)}
 										</li>
 										<li className="mb-2">
-											{modelImages.length ? (
+											{validHistologyImages.length ? (
 												<Link
 													replace
 													href="#histology-images"
@@ -1418,38 +1434,39 @@ const ModelDetails = ({
 									</div>
 								</div>
 							)}
-							{modelImages.length > 0 && (
+							{validHistologyImages.length > 0 && (
 								<div id="histology-images" className="row mb-5 pt-3">
 									<div className="col-12 mb-1">
 										<h2 className="mt-0">Histology images</h2>
 									</div>
 									<div className="col-12">
 										<div className="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-gap-3">
-											{modelImages.map(({ url, description }) => (
-												<div key={url} className="col">
-													<div className="ar-16-9 overflow-hidden mb-1">
-														<Link
-															href={url}
-															target="_blank"
-															rel="noopener"
-															onClick={() =>
-																ReactGA.event("histologyImg_click", {
-																	category: "event"
-																})
-															}
-														>
-															{/* Image component isnt working for external source */}
-															<img
-																src={url}
-																alt={description}
-																width={500}
-																height={300}
-																className="mb-1 h-auto w-100 object-fit-cover"
-															/>
-														</Link>
+											{validHistologyImages.map(({ url, description }) => (
+												<ImageChecker src={url}>
+													<div className="col" key={url}>
+														<div className="ar-16-9 overflow-hidden mb-1">
+															<Link
+																href={url}
+																target="_blank"
+																rel="noopener"
+																onClick={() =>
+																	ReactGA.event("histologyImg_click", {
+																		category: "event"
+																	})
+																}
+															>
+																<Image
+																	src={url}
+																	alt={description}
+																	width={500}
+																	height={300}
+																	className="mb-1 h-auto w-100 object-fit-cover"
+																/>
+															</Link>
+														</div>
+														<p className="text-small mb-0">{description}</p>
 													</div>
-													<p className="text-small mb-0">{description}</p>
-												</div>
+												</ImageChecker>
 											))}
 										</div>
 									</div>

--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -1442,8 +1442,8 @@ const ModelDetails = ({
 									<div className="col-12">
 										<div className="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-gap-3">
 											{validHistologyImages.map(({ url, description }) => (
-												<ImageChecker src={url}>
-													<div className="col" key={url}>
+												<ImageChecker src={url} key={url}>
+													<div className="col">
 														<div className="ar-16-9 overflow-hidden mb-1">
 															<Link
 																href={url}

--- a/src/types/ModelData.model.ts
+++ b/src/types/ModelData.model.ts
@@ -154,6 +154,7 @@ export type ModelImage = {
 	passage: string;
 	magnification: string;
 	staining: string;
+	isBroken: boolean;
 };
 
 export type ModelRelationships = {

--- a/src/utils/imageIsBrokenChecker.ts
+++ b/src/utils/imageIsBrokenChecker.ts
@@ -1,0 +1,40 @@
+const checkImages = (url: string): Promise<boolean> => {
+	return new Promise((resolve) => {
+		// Check if running on the client side
+		if (typeof window === "undefined") {
+			// Resolve false if on the server since we cannot check the image
+			resolve(false);
+			return;
+		}
+
+		const img = new window.Image();
+		img.onload = () => resolve(false); // Image loaded successfully
+		img.onerror = () => resolve(true); // Error loading image
+		img.src = url;
+	});
+};
+
+const imageIsBrokenChecker = async <T extends { url: string }>(
+	images: T[]
+): Promise<T[]> => {
+	try {
+		// map to an array of promises and resolve
+		const checkedImages = await Promise.all(
+			images.map(async (image: T) => {
+				const isBroken = await checkImages(image.url);
+
+				return { ...image, isBroken };
+			})
+		);
+
+		// only return non-broken images
+		return checkedImages.filter((image) => !image.isBroken);
+	} catch (error) {
+		console.error("Error checking images:", error);
+
+		// return unmodified images
+		return images;
+	}
+};
+
+export default imageIsBrokenChecker;


### PR DESCRIPTION
## Issue
Fixes #457 

## Description
We shouldn't show broken images, it's bad ui

## Testing instructions
`http://localhost:3000/data/models/JAX/TM00025#histology-images`
`http://localhost:3000/data/models/CRL/CRL-401#histology-images`

## Screenshots (optional)
