### PR TITLE
Change Image component to img tag for histology images

### DIFF
--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -5,7 +5,6 @@ import JSZip from "jszip";
 import { GetStaticPaths, GetStaticProps } from "next";
 import dynamic from "next/dynamic";
 import Head from "next/head";
-import Image from "next/image";
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
 import ReactGA from "react-ga4";
@@ -1455,7 +1454,7 @@ const ModelDetails = ({
 																	})
 																}
 															>
-																<Image
+																<img
 																	src={url}
 																	alt={description}
 																	width={500}


### PR DESCRIPTION
## Issue
Fixes #459 

## Description
External images aren't loading for histology images when using next/image

## Testing instructions
At the time of this issue: `https://dev.cancermodels.org/data/models/JAX/TM00025#histology-images`
`http://localhost:3000/data/models/JAX/TM00025#histology-images`

## Screenshots (optional)
