### PR TITLE
Fetch facet operators before search results (useQuery.enable)

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -266,7 +266,7 @@ const Search: NextPage = () => {
 				sortBy,
 				searchFacetOperators
 			),
-		enabled: searchFilterState !== null // Only enable when `searchFilterState` is ready
+		enabled: searchFilterState !== null || searchFacetOperators.length > 0 // Only enable when `searchFilterState` and facet operators are ready
 	});
 
 	useEffect(() => {


### PR DESCRIPTION
## Issue
Fixes #468 

## Description
Search results are loading before fetching operators, making calls to api with fallback/default (maybe wrong) operators

## Testing instructions
use filters

## Screenshots (optional)
