### PR TITLE
Home page: Add provider names to provider logos 

### DIFF
--- a/src/pages/about/providers/index.tsx
+++ b/src/pages/about/providers/index.tsx
@@ -153,11 +153,11 @@ const Providers: NextPage<IProvidersProps> = ({ allProvidersBasics }) => {
 	const { activeProjectData, isLoadingProviders, handleProjectClick } =
 		useActiveProject();
 
-	const activeProviders = allProvidersBasics.filter((provider) => {
-		for (const key in activeProjectData.providers) {
-			return key === provider.abbreviation;
-		}
-	});
+	const activeProviderBasics = allProvidersBasics.filter((providerBasic) =>
+		activeProjectData.providers?.some(
+			(provider) => provider?.data_source === providerBasic.abbreviation
+		)
+	);
 
 	return (
 		<>
@@ -223,7 +223,7 @@ const Providers: NextPage<IProvidersProps> = ({ allProvidersBasics }) => {
 									<Loader />
 								</div>
 							) : (
-								activeProviders?.map((provider) => (
+								activeProviderBasics?.map((provider) => (
 									<ProviderInfo key={provider.id} provider={provider} />
 								))
 							)}

--- a/src/pages/about/providers/index.tsx
+++ b/src/pages/about/providers/index.tsx
@@ -25,18 +25,6 @@ interface IProvidersProps {
 	}[];
 }
 
-export interface IProjectData {
-	project_abbreviation: string;
-	project_full_name?: string;
-	providers?: string[];
-	project_settings: {
-		main_color: string;
-		secondary_color: string;
-		logo?: string;
-	};
-	project_description?: string;
-}
-
 interface IProjectButtonProps {
 	projectName: string;
 	isActive: boolean;
@@ -165,9 +153,11 @@ const Providers: NextPage<IProvidersProps> = ({ allProvidersBasics }) => {
 	const { activeProjectData, isLoadingProviders, handleProjectClick } =
 		useActiveProject();
 
-	const activeProviders = allProvidersBasics.filter((provider) =>
-		activeProjectData.providers?.includes(provider.abbreviation)
-	);
+	const activeProviders = allProvidersBasics.filter((provider) => {
+		for (const key in activeProjectData.providers) {
+			return key === provider.abbreviation;
+		}
+	});
 
 	return (
 		<>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -130,24 +130,24 @@ const Home: NextPage = () => {
 									</>
 								) : null}
 								{/* provider logos */}
-								<div className="row row-cols-2 row-cols-md-3 row-cols-lg-4 align-center">
+								<div className="row row-cols-2 row-cols-md-3 row-cols-lg-4">
 									{activeProjectData.providers?.map((provider) => (
 										<div
 											key={provider?.data_source}
-											className="col text-center mb-3"
+											className="col text-center"
 										>
 											<Link
 												href={`/search?filters=data_source%3A${provider?.data_source}`}
 												title={`Explore all ${provider?.data_source} models`}
 												style={{ height: "100px" }}
-												className="mb-1"
+												className="mb-1 d-flex"
 											>
 												<img
 													src={`/img/providers/${provider?.data_source}.png`}
 													alt={`${provider?.data_source} logo`}
 													title={provider?.provider_name}
-													className="w-75 h-auto mx-auto"
-													style={{ maxHeight: "100px" }}
+													className="w-auto h-auto m-auto"
+													style={{ maxHeight: "100px", maxWidth: "75%" }}
 												/>
 											</Link>
 											<p className="text-small text-muted">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -133,7 +133,7 @@ const Home: NextPage = () => {
 								<div className="row row-cols-2 row-cols-md-3 row-cols-lg-4 align-center">
 									{activeProjectData.providers?.map((provider) => (
 										<div
-											key={provider?.provider_name}
+											key={provider?.data_source}
 											className="col text-center mb-3"
 										>
 											<Link

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -132,18 +132,24 @@ const Home: NextPage = () => {
 								{/* provider logos */}
 								<div className="row row-cols-2 row-cols-md-3 row-cols-lg-4 align-center">
 									{activeProjectData.providers?.map((provider) => (
-										<div key={provider} className="col text-center mb-3">
+										<div
+											key={provider?.provider_name}
+											className="col text-center mb-3"
+										>
 											<Link
-												href={`/search?filters=data_source%3A${provider}`}
-												title={`Explore all ${provider} models`}
+												href={`/search?filters=data_source%3A${provider?.data_source}`}
+												title={`Explore all ${provider?.data_source} models`}
 											>
-												<img
-													src={`/img/providers/${provider}.png`}
-													alt={`${provider} logo`}
-													title={provider}
-													className="w-75 h-auto mx-auto"
-													style={{ maxHeight: "100px" }}
-												/>
+												<div>
+													<img
+														src={`/img/providers/${provider?.data_source}.png`}
+														alt={`${provider?.data_source} logo`}
+														title={provider?.provider_name}
+														className="w-75 h-auto mx-auto"
+														style={{ maxHeight: "100px" }}
+													/>
+												</div>
+												<p className="text-small">{provider?.provider_name}</p>
 											</Link>
 										</div>
 									))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -139,18 +139,20 @@ const Home: NextPage = () => {
 											<Link
 												href={`/search?filters=data_source%3A${provider?.data_source}`}
 												title={`Explore all ${provider?.data_source} models`}
+												style={{ height: "100px" }}
+												className="mb-1"
 											>
-												<div>
-													<img
-														src={`/img/providers/${provider?.data_source}.png`}
-														alt={`${provider?.data_source} logo`}
-														title={provider?.provider_name}
-														className="w-75 h-auto mx-auto"
-														style={{ maxHeight: "100px" }}
-													/>
-												</div>
-												<p className="text-small">{provider?.provider_name}</p>
+												<img
+													src={`/img/providers/${provider?.data_source}.png`}
+													alt={`${provider?.data_source} logo`}
+													title={provider?.provider_name}
+													className="w-75 h-auto mx-auto"
+													style={{ maxHeight: "100px" }}
+												/>
 											</Link>
+											<p className="text-small text-muted">
+												{provider?.provider_name}
+											</p>
 										</div>
 									))}
 								</div>

--- a/src/utils/hooks/useActiveProject.ts
+++ b/src/utils/hooks/useActiveProject.ts
@@ -5,10 +5,10 @@ import { getDataSourcesByProject } from "../../apis/Search.api";
 import { addProvidersToProjectData } from "../projects";
 import projectsSettings from "../projectSettings.json";
 
-interface IProjectData {
+export interface IProjectData {
 	project_abbreviation: string;
 	project_full_name?: string;
-	providers?: string[];
+	providers?: ({ data_source: string; provider_name: string } | undefined)[];
 	project_description?: string;
 	project_settings: {
 		main_color: string;

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -1,4 +1,4 @@
-import { IProjectData } from "../pages/about/providers";
+import { IProjectData } from "./hooks/useActiveProject";
 
 export const addProvidersToProjectData = (
 	projectData: IProjectData,
@@ -7,7 +7,22 @@ export const addProvidersToProjectData = (
 	const uniqueValues = [
 		...new Set(dataSources.map((item) => item.data_source))
 	];
-	projectData.providers = uniqueValues.sort((a, b) => a.localeCompare(b));
+	const providers = uniqueValues.map((provider) =>
+		dataSources.find((source) => source.data_source === provider)
+	);
+
+	projectData.providers = providers.sort((a, b) =>
+		(a?.data_source ?? "").localeCompare(b?.data_source ?? "")
+	);
 
 	return projectData;
 };
+
+/*
+{
+  "ACC": "Alliance Against Cancer",
+  "CRO": "Cancer Research Organization",
+}
+
+providers[abbreviation]
+*/

--- a/src/utils/sortArrBy.ts
+++ b/src/utils/sortArrBy.ts
@@ -1,33 +1,28 @@
-export const sortObjArrBy = (
-	currArr: any[],
-	sortArr: string[],
-	sortBy: string | undefined,
-	newArr?: boolean,
-	sendItemsToEnd?: boolean
-) => {
-	sortArr.reverse();
-	if (sendItemsToEnd) currArr.reverse();
+export const sortObjectArrayBy = (
+	array: any[],
+	sortOrder: string[],
+	sortProperty?: string,
+	returnNewArray?: boolean,
+	reverseOriginalArray?: boolean
+): any[] => {
+	const sortedArray = [...array];
+	const sortMap = Object.fromEntries(
+		sortOrder.map((value, index) => [value.toLowerCase(), index])
+	);
 
-	if (sortBy && currArr[0].hasOwnProperty(sortBy)) {
-		if (newArr) {
-			return currArr
-				.slice()
-				.sort(
-					(a, b) =>
-						sortArr.indexOf(b[sortBy].toLowerCase()) -
-						sortArr.indexOf(a[sortBy].toLowerCase())
-				);
-		} else {
-			currArr.sort(
-				(a, b) =>
-					sortArr.indexOf(b[sortBy].toLowerCase()) -
-					sortArr.indexOf(a[sortBy].toLowerCase())
-			);
-		}
+	if (sortProperty) {
+		sortedArray.sort((a, b) => {
+			const aValue = (a[sortProperty] || "").toLowerCase();
+			const bValue = (b[sortProperty] || "").toLowerCase();
+			return sortMap[bValue] - sortMap[aValue];
+		});
 	} else {
-		currArr.sort(
-			(a, b) =>
-				sortArr.indexOf(a.toLowerCase()) - sortArr.indexOf(b.toLowerCase())
+		sortedArray.sort(
+			(a, b) => sortMap[b.toLowerCase()] - sortMap[a.toLowerCase()]
 		);
 	}
+
+	if (returnNewArray) sortedArray;
+	if (reverseOriginalArray) array.reverse();
+	return array;
 };

--- a/src/utils/sortArrBy.ts
+++ b/src/utils/sortArrBy.ts
@@ -1,28 +1,33 @@
-export const sortObjectArrayBy = (
-	array: any[],
-	sortOrder: string[],
-	sortProperty?: string,
-	returnNewArray?: boolean,
-	reverseOriginalArray?: boolean
-): any[] => {
-	const sortedArray = [...array];
-	const sortMap = Object.fromEntries(
-		sortOrder.map((value, index) => [value.toLowerCase(), index])
-	);
+export const sortObjArrBy = (
+	currArr: any[],
+	sortArr: string[],
+	sortBy: string | undefined,
+	newArr?: boolean,
+	sendItemsToEnd?: boolean
+) => {
+	sortArr.reverse();
+	if (sendItemsToEnd) currArr.reverse();
 
-	if (sortProperty) {
-		sortedArray.sort((a, b) => {
-			const aValue = (a[sortProperty] || "").toLowerCase();
-			const bValue = (b[sortProperty] || "").toLowerCase();
-			return sortMap[bValue] - sortMap[aValue];
-		});
+	if (sortBy && currArr[0].hasOwnProperty(sortBy)) {
+		if (newArr) {
+			return currArr
+				.slice()
+				.sort(
+					(a, b) =>
+						sortArr.indexOf(b[sortBy].toLowerCase()) -
+						sortArr.indexOf(a[sortBy].toLowerCase())
+				);
+		} else {
+			currArr.sort(
+				(a, b) =>
+					sortArr.indexOf(b[sortBy].toLowerCase()) -
+					sortArr.indexOf(a[sortBy].toLowerCase())
+			);
+		}
 	} else {
-		sortedArray.sort(
-			(a, b) => sortMap[b.toLowerCase()] - sortMap[a.toLowerCase()]
+		currArr.sort(
+			(a, b) =>
+				sortArr.indexOf(a.toLowerCase()) - sortArr.indexOf(b.toLowerCase())
 		);
 	}
-
-	if (returnNewArray) sortedArray;
-	if (reverseOriginalArray) array.reverse();
-	return array;
 };


### PR DESCRIPTION
## Issue
Fixes #502 

## Description
Add full provider names for easy identification since there are some repeated logos. Also good for SEO

## Testing instructions
`localhost:3000`

## Screenshots (optional)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/17793054-c952-413c-90e3-caa3fc066b58">

