### PR TITLE
Add model type to compare page

### DIFF
--- a/src/pages/compare.tsx
+++ b/src/pages/compare.tsx
@@ -9,6 +9,7 @@ import { useQueries } from "react-query";
 import { getAllModelData } from "../apis/ModelDetails.api";
 import Button from "../components/Button/Button";
 import FloatingButton from "../components/FloatingWidget/FloatingButton";
+import ModelTypeIcon from "../components/Icons/ModelTypeIcon";
 import Loader from "../components/Loader/Loader";
 import QualityBadge from "../components/QualityBadge/QualityBadge";
 import ShowHide from "../components/ShowHide/ShowHide";
@@ -120,7 +121,7 @@ const Compare: NextPage = () => {
 										<div className="col" key={metadata.modelId}>
 											{/* quality badge always at baseline */}
 											<div className="d-flex flex-column h-100 justify-content-between">
-												<div>
+												<div className="mb-1">
 													<sub>
 														<Button
 															color="dark"
@@ -153,7 +154,11 @@ const Compare: NextPage = () => {
 															{metadata.modelId}
 														</Link>
 													</h1>
-													<h2 className="p mt-0">{metadata.histology}</h2>
+													<h2 className="p mt-0 mb-1">{metadata.histology}</h2>
+													<ModelTypeIcon
+														modelType={metadata.modelType}
+														size="1.5em"
+													/>
 												</div>
 												<QualityBadge
 													className="w-50"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 // Documents/cancer-models/src/pages/index.tsx
 import type { NextPage } from "next";
 import dynamic from "next/dynamic";
+import Image from "next/image";
 import Link from "next/link";
 import { useQuery } from "react-query";
 import { getModelCount } from "../apis/AggregatedData.api";
@@ -142,11 +143,13 @@ const Home: NextPage = () => {
 												style={{ height: "100px" }}
 												className="mb-1 d-flex"
 											>
-												<img
+												<Image
 													src={`/img/providers/${provider?.data_source}.png`}
-													alt={`${provider?.data_source} logo`}
+													alt={`${provider?.provider_name} logo`}
 													title={provider?.provider_name}
 													className="w-auto h-auto m-auto"
+													width={300}
+													height={100}
 													style={{ maxHeight: "100px", maxWidth: "75%" }}
 												/>
 											</Link>


### PR DESCRIPTION
## Issue
Fixes #504 

## Description
Add model type icons to compare page models

## Testing instructions
`http://localhost:3000/compare?models=SIDM01378+HCM-CSHL-0246-C19+CRL-508+HCM-BROD-0106-C71`

## Screenshots (optional)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5e8da612-d9ef-4a97-9398-98326ab48db2">

