### PR TITLE
Add label to ATCC supplier puchase button

### DIFF
--- a/src/components/ModelPurchaseButton/ModelPurchaseButton.tsx
+++ b/src/components/ModelPurchaseButton/ModelPurchaseButton.tsx
@@ -19,9 +19,8 @@ const ModelPurchaseButton = ({
 			href={supplier.link}
 			className={`${isLastSupplier ? "mt-0" : ""}`}
 		>{`Purchase at ${
-			supplier.resourceLabel + supplier.resourceLabel.includes("ATCC")
-				? " " + supplier.linkLabel
-				: ""
+			supplier.resourceLabel +
+			(supplier.resourceLabel.includes("ATCC") ? " " + supplier.linkLabel : "")
 		}`}</Button>
 	);
 };

--- a/src/components/ModelPurchaseButton/ModelPurchaseButton.tsx
+++ b/src/components/ModelPurchaseButton/ModelPurchaseButton.tsx
@@ -18,7 +18,11 @@ const ModelPurchaseButton = ({
 			htmlTag="a"
 			href={supplier.link}
 			className={`${isLastSupplier ? "mt-0" : ""}`}
-		>{`Purchase at ${supplier.resourceLabel}`}</Button>
+		>{`Purchase at ${
+			supplier.resourceLabel + supplier.resourceLabel.includes("ATCC")
+				? " " + supplier.linkLabel
+				: ""
+		}`}</Button>
 	);
 };
 


### PR DESCRIPTION
## Issue
Fixes #507 

## Description
Append linkLabel to resourceLabel only for ATCC supplier

## Testing instructions
http://localhost:3000/data/models/BROD/HCM-BROD-0198-C71

## Screenshots (optional)
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/241ed38e-1934-4d83-b24b-fa8c5fb2c7a9">

