### PR TITLE
Clear filter options when blur

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,19 +1,20 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import Accordion from "./Accordion";
 
 export default {
 	title: "UI/Accordion",
-	component: Accordion,
+	component: Accordion
 } as ComponentMeta<typeof Accordion>;
 
 const Template: ComponentStory<typeof Accordion> = (args) => (
-	<Accordion {...args} />
+	<Accordion {...args}>
+		<p>This is the content for the accordion</p>
+	</Accordion>
 );
 
 export const Component = Template.bind({});
 Component.args = {
 	id: "Accordion id",
-	content: <p>This is the content for the accordion</p>,
 	buttonClassName: "bg-gray",
-	contentClassName: "bg-lightGray",
+	contentClassName: "bg-lightGray"
 };

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -7,9 +7,9 @@ interface IAccordionProps {
 	buttonClassName?: string;
 	className?: string;
 	id: string;
-	content: any;
 	contentClassName?: string;
 	open?: boolean;
+	children: JSX.Element;
 }
 
 const Accordion = (props: IAccordionProps) => {
@@ -41,7 +41,7 @@ const Accordion = (props: IAccordionProps) => {
 			<div id={ariaId}>
 				{isOpen && (
 					<div className={`px-1 ${contentClassName}`.trim()}>
-						{props.content}
+						{props.children}
 					</div>
 				)}
 			</div>

--- a/src/components/SearchFilters/MultivaluedSearchFilter.tsx
+++ b/src/components/SearchFilters/MultivaluedSearchFilter.tsx
@@ -1,0 +1,95 @@
+import { memo, useEffect, useState } from "react";
+import { useQuery } from "react-query";
+import Select from "react-select";
+import { autoCompleteFacetOptions } from "../../apis/Search.api";
+import { onFilterChangeType } from "../../pages/search";
+import { IFacetProps, IFacetSectionSelection } from "../../types/Facet.model";
+import typeaheadStyles from "../../utils/typeaheadStyles";
+import Fragment from "../Fragment/Fragment";
+import { SelectOption } from "./SearchFilterContent";
+
+type Props = {
+	facet: IFacetProps;
+	defaultValues: SelectOption[];
+	onFilterChange: any;
+	operator: IFacetSectionSelection["operator"];
+};
+
+const MultivaluedSearchFilter = ({
+	facet,
+	defaultValues,
+	onFilterChange,
+	operator
+}: Props) => {
+	const [query, setQuery] = useState("");
+	const [facetId, setfacetId] = useState("");
+	const [typeaheadData, setTypeaheadData] = useState<SelectOption[]>();
+
+	let selectOptionsQuery = useQuery(
+		[facetId, query],
+		() => autoCompleteFacetOptions(facetId, query),
+		{
+			onSuccess(data) {
+				setTypeaheadData(data);
+			}
+		}
+	);
+
+	useEffect(() => {
+		setTypeaheadData(selectOptionsQuery.data);
+	}, [query, facetId, selectOptionsQuery.data]);
+
+	const onTypeaheadType = (facetId: string, query: string) => {
+		setQuery(query);
+		setfacetId(facetId);
+	};
+
+	const placeholder = facet.placeholder
+		? `Eg. ${facet.placeholder}`
+		: "Select...";
+
+	return (
+		<Select
+			closeMenuOnSelect
+			blurInputOnSelect
+			isMulti
+			defaultValue={defaultValues}
+			value={defaultValues}
+			placeholder={placeholder}
+			options={typeaheadData}
+			onInputChange={(inputValue) => onTypeaheadType(facet.facetId, inputValue)}
+			onFocus={() => {
+				// reset options, theyre maintaining even after changing Selects
+				setTypeaheadData([]);
+			}}
+			isLoading={selectOptionsQuery.isLoading}
+			loadingMessage={() => "Loading data"}
+			noOptionsMessage={() => "Type to search"}
+			onChange={(_, actionMeta) => {
+				if (actionMeta.action === "pop-value") return;
+
+				let option = "",
+					action: onFilterChangeType["type"] = "add";
+
+				switch (actionMeta.action) {
+					case "remove-value":
+						option = actionMeta.removedValue.value;
+						action = "remove";
+						break;
+					case "select-option":
+						option = actionMeta.option!.value;
+						break;
+					case "clear":
+						action = "clear";
+						break;
+				}
+
+				onFilterChange(facet.facetId, option, operator, action);
+			}}
+			styles={typeaheadStyles}
+			components={{ DropdownIndicator: Fragment }}
+		/>
+	);
+};
+
+export default memo(MultivaluedSearchFilter);

--- a/src/components/SearchFilters/SearchFilterContent.tsx
+++ b/src/components/SearchFilters/SearchFilterContent.tsx
@@ -33,7 +33,7 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 	const [typeaheadData, setTypeaheadData] = useState<SelectOption[]>();
 
 	let selectOptionsQuery = useQuery(
-		query,
+		[facetId, query],
 		() => autoCompleteFacetOptions(facetId, query),
 		{
 			onSuccess(data) {
@@ -44,7 +44,7 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 
 	useEffect(() => {
 		setTypeaheadData(selectOptionsQuery.data);
-	}, [query, facetId]);
+	}, [query, facetId, selectOptionsQuery.data]);
 
 	const onTypeaheadType = (facetId: string, query: string) => {
 		setQuery(query);
@@ -92,6 +92,10 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 								onInputChange={(inputValue) =>
 									onTypeaheadType(facet.facetId, inputValue)
 								}
+								onFocus={() => {
+									// reset options, theyre maintaining even after changing Selects
+									setTypeaheadData([]);
+								}}
 								isLoading={selectOptionsQuery.isLoading}
 								loadingMessage={() => "Loading data"}
 								noOptionsMessage={() => "Type to search"}

--- a/src/components/SearchFilters/SearchFilterContent.tsx
+++ b/src/components/SearchFilters/SearchFilterContent.tsx
@@ -1,14 +1,12 @@
-import { ChangeEvent, useEffect, useState } from "react";
-import { useQuery } from "react-query";
+import { ChangeEvent } from "react";
 import Select from "react-select";
-import { autoCompleteFacetOptions } from "../../apis/Search.api";
 import { onFilterChangeType } from "../../pages/search";
 import { IFacetProps, IFacetSidebarSelection } from "../../types/Facet.model";
 import { ethnicityCategories } from "../../utils/collapseEthnicity";
 import typeaheadStyles from "../../utils/typeaheadStyles";
-import Fragment from "../Fragment/Fragment";
 import InformationIcon from "../InformationIcon/InformationIcon";
 import InputAndLabel from "../Input/InputAndLabel";
+import MultivaluedSearchFilter from "./MultivaluedSearchFilter";
 
 interface ISearchFilterContentProps {
 	data: IFacetProps[];
@@ -28,29 +26,6 @@ export interface SelectOption {
 }
 
 const SearchFilterContent = (props: ISearchFilterContentProps) => {
-	const [query, setQuery] = useState("");
-	const [facetId, setfacetId] = useState("");
-	const [typeaheadData, setTypeaheadData] = useState<SelectOption[]>();
-
-	let selectOptionsQuery = useQuery(
-		[facetId, query],
-		() => autoCompleteFacetOptions(facetId, query),
-		{
-			onSuccess(data) {
-				setTypeaheadData(data);
-			}
-		}
-	);
-
-	useEffect(() => {
-		setTypeaheadData(selectOptionsQuery.data);
-	}, [query, facetId, selectOptionsQuery.data]);
-
-	const onTypeaheadType = (facetId: string, query: string) => {
-		setQuery(query);
-		setfacetId(facetId);
-	};
-
 	const optionSelectObj = (options: string[]): SelectOption[] => {
 		return options?.map((value: string) => ({
 			["label"]: value,
@@ -73,55 +48,16 @@ const SearchFilterContent = (props: ISearchFilterContentProps) => {
 
 				const defaultValues = optionSelectObj(selection);
 
-				if (facetType === "autocomplete" || facetType === "multivalued") {
-					const placeholder = facet.placeholder
-							? `Eg. ${facet.placeholder}`
-							: "Select...",
-						displayOperators = facetType === "multivalued";
+				const displayOperators = facetType === "multivalued";
 
+				if (facetType === "autocomplete" || facetType === "multivalued") {
 					facetContent = (
 						<>
-							<Select
-								closeMenuOnSelect
-								blurInputOnSelect
-								isMulti
-								defaultValue={defaultValues}
-								value={defaultValues}
-								placeholder={placeholder}
-								options={typeaheadData}
-								onInputChange={(inputValue) =>
-									onTypeaheadType(facet.facetId, inputValue)
-								}
-								onFocus={() => {
-									// reset options, theyre maintaining even after changing Selects
-									setTypeaheadData([]);
-								}}
-								isLoading={selectOptionsQuery.isLoading}
-								loadingMessage={() => "Loading data"}
-								noOptionsMessage={() => "Type to search"}
-								onChange={(_, actionMeta) => {
-									if (actionMeta.action === "pop-value") return;
-
-									let option = "",
-										action: onFilterChangeType["type"] = "add";
-
-									switch (actionMeta.action) {
-										case "remove-value":
-											option = actionMeta.removedValue.value;
-											action = "remove";
-											break;
-										case "select-option":
-											option = actionMeta.option!.value;
-											break;
-										case "clear":
-											action = "clear";
-											break;
-									}
-
-									props.onFilterChange(facet.facetId, option, operator, action);
-								}}
-								styles={typeaheadStyles}
-								components={{ DropdownIndicator: Fragment }}
+							<MultivaluedSearchFilter
+								facet={facet}
+								defaultValues={defaultValues}
+								onFilterChange={props.onFilterChange}
+								operator={operator}
 							/>
 							{displayOperators && (
 								<fieldset className="d-flex border-none m-0">

--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -1,13 +1,13 @@
-import Accordion from "../Accordion/Accordion";
-import SearchFilterContent from "./SearchFilterContent";
-import Card from "../Card/Card";
-import {
-	IFacetSidebarSelection,
-	IFacetSectionProps,
-} from "../../types/Facet.model";
-import { sortObjArrBy } from "../../utils/sortArrBy";
 import { useEffect, useState } from "react";
 import { onFilterChangeType } from "../../pages/search";
+import {
+	IFacetSectionProps,
+	IFacetSidebarSelection
+} from "../../types/Facet.model";
+import { sortObjArrBy } from "../../utils/sortArrBy";
+import Accordion from "../Accordion/Accordion";
+import Card from "../Card/Card";
+import SearchFilterContent from "./SearchFilterContent";
 
 interface ISearchFilters {
 	data: IFacetSectionProps[];
@@ -67,15 +67,14 @@ const SearchFilters = (props: ISearchFilters) => {
 						id={facet.name}
 						contentClassName="mb-3"
 						open={isModelFacet}
-						content={
-							<SearchFilterContent
-								onFilterChange={props.onFilterChange}
-								data={facets}
-								facet={facet}
-								facetSelection={props.selection}
-							/>
-						}
-					/>
+					>
+						<SearchFilterContent
+							onFilterChange={props.onFilterChange}
+							data={facets}
+							facet={facet}
+							facetSelection={props.selection}
+						/>
+					</Accordion>
 				);
 			})}
 		</Card>

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -13,12 +13,12 @@ export function camelCase<T extends Record<string, any>>(
 	obj: T
 ): CamelCaseKeys<T> {
 	if (Array.isArray(obj)) {
-		return obj.map((v) => camelCase(v)) as any;
-	} else if (obj !== null && typeof obj === "object") {
+		return obj.map(camelCase) as any;
+	} else if (obj && typeof obj === "object") {
 		return Object.fromEntries(
 			Object.entries(obj).map(([k, v]) => [
 				k.replace(/_([a-z])/g, (_, p1) => p1.toUpperCase()).replace(/_/g, ""),
-				v !== null && typeof v === "object" ? camelCase(v) : v
+				v && typeof v === "object" ? camelCase(v) : v
 			])
 		) as CamelCaseKeys<T>;
 	}


### PR DESCRIPTION
## Issue
Fixes #523 

## Description
Clear filter options when onBlur so they aren't maintained from Select to Select

## Testing instructions
Type 'e' on Treatment Type filter, then type 'e' on Model Drug Dosing filter. There should be different options

## Screenshots (optional)
<img width="356" alt="image" src="https://github.com/user-attachments/assets/d2739314-0d96-43b0-b87e-9a8e8e3844c4">
<img width="332" alt="image" src="https://github.com/user-attachments/assets/7afe808b-da7a-4d0f-b570-77c142b35a1a">


