### PR TITLE
Provider page accepts upper or lowercase IDs in URL

### DIFF
--- a/src/components/SearchResults/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult/SearchResult.tsx
@@ -98,10 +98,7 @@ const SearchResult = (props: SearchResultProps) => {
 							<Link href={modelLink}>{pdcmId}</Link>
 						</h2>
 						<p className="text-capitalize mb-0">
-							<Link
-								href={`/about/providers/${sourceId?.toLowerCase()}`}
-								title={providerName}
-							>
+							<Link href={`/about/providers/${sourceId}`} title={providerName}>
 								{`${providerName?.substring(0, 50)}${
 									providerName?.length > 50 ? "..." : ""
 								}`}

--- a/src/pages/about/providers/[id].tsx
+++ b/src/pages/about/providers/[id].tsx
@@ -83,7 +83,9 @@ export const getStaticPaths: GetStaticPaths = async () => {
 };
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-	const providerData = await getProviderData(params?.id as string);
+	const providerData = await getProviderData(
+		(params?.id as string).toLowerCase() // transform to lowercase so any cased abbrev works
+	);
 
 	return {
 		props: {

--- a/src/pages/data/models/[providerId]/[modelId].tsx
+++ b/src/pages/data/models/[providerId]/[modelId].tsx
@@ -1805,7 +1805,7 @@ const ModelDetails = ({
 							)}
 							<div id="preclinical-imaging" className="row mb-5 pt-3">
 								<div className="col-12 mb-1">
-									<h2 className="mt-0 mb-4">Preclinical imaging</h2>
+									<h2 className="mt-0">Preclinical imaging</h2>
 								</div>
 								<div className="col-12">
 									<div className="w-100 d-flex align-flex-start align-md-start flex-column flex-md-row justify-content-between row-gap-1">
@@ -1820,7 +1820,6 @@ const ModelDetails = ({
 												className="my-0"
 												htmlTag="a"
 												href="https://pixi-demo.nrg.wustl.edu/data/projects/PDMR-425362-245-T?format=html"
-												style={{ flex: "none" }}
 											>
 												<Image
 													src="/img/pixi-logo.png"
@@ -1834,7 +1833,6 @@ const ModelDetails = ({
 												htmlTag="a"
 												priority="secondary"
 												color="dark"
-												onClick={() => console.log("all")}
 												className="my-0"
 												href="/static/mock-preclinical_imaging_description_document.pdf"
 											>


### PR DESCRIPTION
## Issue
Fixes #626 

## Description
update getStaticProps to use the id in lowercase to get data

## Testing instructions

## Screenshots (optional)
